### PR TITLE
fix: update entry_points to use gradio.cli, not gradio.reload

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,45 +10,46 @@ source:
   sha256: 3ebc5f4b2d7126b42d1f36b937c44703e94991b40cb8f20338227a826048d349
 
 build:
-  number: 0
-  noarch: python
   entry_points:
-    - gradio=gradio.reload:run_in_reload_mode
-  script: {{ PYTHON }} -m pip install . -vv
+    - gradio = gradio.cli:cli
+    - upload_theme = gradio.themes.upload_theme:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
 
 requirements:
   host:
-    - python >=3.7
-    - pip
+    - python >=3.8
     - hatchling
     - hatch-requirements-txt
     - hatch-fancy-pypi-readme >=22.5.0
+    - pip
   run:
     - python >=3.8
-    - aiofiles >=22.0,<24.0
-    - altair >=4.2.0,<6.0
+    - aiofiles <24.0,>=22.0
+    - altair <6.0,>=4.2.0
     - fastapi
     - ffmpy
     - gradio-client ==0.8.0
     - httpx
     - huggingface_hub >=0.19.3
-    - importlib_resources >=1.3,<7.0
+    - importlib-resources <7.0,>=1.3
     - jinja2 <4.0
-    - markupsafe ~=2.0
-    - matplotlib-base ~=3.0
-    - numpy ~=1.0
-    - orjson ~=3.0
+    - markupsafe >=2.0,<3.dev0
+    - matplotlib-base >=3.0,<4.dev0
+    - numpy >=1.0,<2.dev0
+    - orjson >=3.0,<4.dev0
     - packaging
-    - pandas >=1.0,<3.0
-    - pillow >=8.0,<11.0
+    - pandas <3.0,>=1.0
+    - pillow <11.0,>=8.0
     - pydantic >=2.0
-    - python-multipart
     - pydub
-    - pyyaml >=5.0,<7.0
-    - semantic_version ~=2.0
+    - python-multipart
+    - pyyaml <7.0,>=5.0
+    - semantic_version >=2.0,<3.dev0
     - tomlkit ==0.12.0
-    - typing-extensions ~=4.0
-    - typer[all] >=0.9,<1.0
+    - typer <1.0,>=0.9
+    - typing-extensions >=4.0,<5.dev0
     - uvicorn >=0.14.0
 
 test:
@@ -56,15 +57,19 @@ test:
     - gradio
   commands:
     - pip check
+    - gradio --help
+    - upload_theme --help
   requires:
     - pip
 
 about:
-  home: https://pypi.org/project/gradio/
   summary: Python library for easily interacting with trained machine learning models
-  license: Apache-2.0
-  license_file: LICENSE
+  license: MIT AND Apache-2.0
+  license_file:
+    - LICENSE
+    - gradio/node/dev/node_modules/esbuild-wasm/LICENSE.md
 
 extra:
   recipe-maintainers:
     - Sclare87
+    - xhiroga

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,6 +63,7 @@ test:
     - pip
 
 about:
+  home: https://pypi.org/project/gradio/
   summary: Python library for easily interacting with trained machine learning models
   license: MIT AND Apache-2.0
   license_file:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     - upload_theme = gradio.themes.upload_theme:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
Fix https://github.com/conda-forge/gradio-feedstock/issues/48

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
