### PR TITLE
Remove ruff from requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,6 @@ requirements:
     - pydub
     - python-multipart >=0.0.9
     - pyyaml <7.0,>=5.0
-    - ruff >=0.2.2
     - semantic_version >=2.0,<3.dev0
     - tomlkit ==0.12.0
     - typer <1.0,>=0.9


### PR DESCRIPTION
ruff is a linting application and should not be a requirement for running

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
