### PR TITLE
Add blocks_events.pyi regression coverage

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,6 +100,37 @@ test:
     - pip check
     - gradio --help
     - upload_theme --help
+    # Regression coverage for conda-forge/gradio-feedstock#103.
+    - |
+      python - <<'PY'
+      import json
+      import os
+      from pathlib import Path
+
+      prefix = Path(os.environ["PREFIX"])
+      records = list()
+      for record_path in sorted((prefix / "conda-meta").glob("gradio*.json")):
+          record = json.loads(record_path.read_text(encoding="utf-8"))
+          if record.get("name") == "gradio":
+              records.append((record_path, record))
+
+      assert len(records) == 1, "found gradio package records: %r" % (records,)
+
+      record_path, record = next(iter(records))
+      packaged_file = "gradio/blocks_events.pyi"
+      assert any(path.endswith(packaged_file) for path in record.get("files", ())), (
+          f"{packaged_file} is missing from package metadata {record_path}"
+      )
+
+      import gradio
+
+      blocks_events = Path(gradio.__file__).with_name("blocks_events.pyi")
+      assert blocks_events.is_file(), f"{blocks_events} is missing"
+
+      contents = blocks_events.read_text(encoding="utf-8")
+      assert "class BlocksEvents" in contents
+      assert "def load(self," in contents
+      PY
   requires:
     - python {{ python_min }}
     - pip


### PR DESCRIPTION
Closes #103.

This adds package-test coverage for the `gradio/blocks_events.pyi` file that issue #103 reported missing in older conda builds. The current published `gradio=6.14.0=pyhd8ed1ab_0` artifact already includes `site-packages/gradio/blocks_events.pyi`, so no package-content recipe fix or rebuild number bump is needed here.

The new test checks the installed conda package record before importing `gradio`, so it catches the file being absent from package metadata even if Gradio could regenerate the file in a writable test environment. It then imports `gradio`, locates the installed `blocks_events.pyi` next to `gradio.__file__`, and verifies the generated `BlocksEvents.load` interface is present.

Local validation:
- `conda-smithy recipe-lint --conda-forge recipe`
- `git diff --check`
- `conda build recipe --output -m .ci_support/linux_64_.yaml -c conda-forge`
- `conda-smithy rerender -c auto` (no changes)
- Isolated conda env with `python=3.10 gradio=6.14.0 pip`: package-record assertion passed, installed-file assertion passed, and `pip check` passed
