### PR TITLE
Support Gradio on Python 3.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
     - gradio = gradio.cli:cli
     - upload_theme = gradio.themes.upload_theme:main
   noarch: python
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -31,7 +31,7 @@ requirements:
     # copied from below
     - aiofiles >=22.0,<25.0
     - anyio >=3.0,<5.0
-    #- audioop-lts <1.0 Not yet avalaible yet and only work with python 313
+    - audioop-lts <=0.2.2
     - fastapi >=0.115.2,<1.0
     - ffmpy
     - groovy-python >=0.1,<0.2
@@ -49,6 +49,7 @@ requirements:
     - pydantic >=2.11.10,<=2.12.5
     - python-multipart >=0.0.18
     - pydub
+    - pytz >=2017.2
     - pyyaml >=5.0,<7.0
     - ruff >=0.9.3
     - safehttpx >=0.1.6,<0.2.0
@@ -61,10 +62,12 @@ requirements:
     - uvicorn >=0.14.0
 
   run:
-    - python >={{ python_min }},<3.13
+    - python >={{ python_min }}
     - aiofiles >=22.0,<25.0
     - anyio >=3.0,<5.0
-    #- audioop-lts <1.0 Not yet avalaible yet and only work with python 313
+    # Upstream needs audioop-lts on Python >=3.13 after stdlib audioop was removed.
+    # Keep it unconditional because noarch conda metadata cannot express Python-version markers.
+    - audioop-lts <=0.2.2
     - fastapi >=0.115.2,<1.0
     - ffmpy
     - groovy-python >=0.1,<0.2
@@ -82,6 +85,7 @@ requirements:
     - pydantic >=2.11.10,<=2.12.5
     - python-multipart >=0.0.18
     - pydub
+    - pytz >=2017.2
     - pyyaml >=5.0,<7.0
     - ruff >=0.9.3
     - safehttpx >=0.1.6,<0.2.0
@@ -100,6 +104,17 @@ test:
     - pip check
     - gradio --help
     - upload_theme --help
+    # Regression coverage for conda-forge/gradio-feedstock#129.
+    - |
+      python - <<'PY'
+      import sys
+
+      assert sys.version_info[:2] == (3, 13), sys.version
+
+      import audioop
+
+      assert audioop.lin2lin(b"\0\0", 2, 1) == b"\0"
+      PY
     # Regression coverage for conda-forge/gradio-feedstock#103.
     - |
       python - <<'PY'
@@ -132,7 +147,8 @@ test:
       assert "def load(self," in contents
       PY
   requires:
-    - python {{ python_min }}
+    # Run noarch tests on Python 3.13 to cover the audioop-lts regression.
+    - python 3.13.*
     - pip
 
 about:


### PR DESCRIPTION
Closes #129

## Summary
- Remove the `<3.13` runtime cap now that `audioop-lts` is available on conda-forge.
- Add `audioop-lts <=0.2.2` unconditionally, matching upstream for Python >=3.13. The package stays `noarch: python` because conda noarch metadata cannot express Python-version dependency markers.
- Add upstream-declared `pytz >=2017.2`; the Python 3.13 import test found this was also required for `import gradio`.
- Run the noarch package tests on Python 3.13 and add regression coverage for the `audioop` replacement.

## Linter note
- The noarch linter may suggest `test.requires: python {{ python_min }}`. This PR intentionally uses `python 3.13.*` there so CI exercises the #129 regression. Using `python {{ python_min }}` would test the minimum supported Python instead and would not verify the Python 3.13 `audioop` removal path.

## Validation
- `conda-smithy rerender -c auto` made no changes.
- `conda-smithy recipe-lint --conda-forge recipe` passed with only the expected noarch Python test-version suggestion.
- `git diff --check HEAD~1..HEAD` passed.
- Full local build/test passed: `conda build recipe -m .ci_support/linux_64_.yaml --croot /tmp/gradio-croot-retry-223366 -c conda-forge`.
- The full test env used Python 3.13, installed `audioop-lts` and `pytz`, and passed `pip check`, `import gradio`, CLI smoke tests, the audioop regression, and the existing packaged-file regression.
- Local-channel dry-run solve passed for `python=3.13 gradio=6.14.0=pyhd8ed1ab_1`.